### PR TITLE
Implement streaming and sentiment analysis pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,84 @@
-# Proyecto-Final
+# Proyecto Final: Streaming y Análisis de Sentimiento
+
+Este proyecto implementa un pipeline completo de **streaming de datos** para analizar comentarios de Twitter en tiempo real utilizando un modelo de *Deep Learning* pre-entrenado. La arquitectura incluye servicios de Kafka, MongoDB, MySQL y Metabase desplegados con Docker.
+
+## Componentes
+
+1. **Clientes (Producers)** – Scripts de Python que envían mensajes aleatorios a Kafka.
+2. **Consumer** – Escucha mensajes de Kafka y los almacena como datos crudos en MongoDB.
+3. **Pipeline de Deep Learning** – Obtiene datos sin procesar de MongoDB, predice el sentimiento con un modelo de HuggingFace y guarda resultados en MySQL.
+4. **Dashboard** – Metabase se conecta a MySQL para visualizar los resultados.
+
+## Requisitos
+
+- Docker y Docker Compose
+- Python 3.10+
+- Dependencias Python (`pip install -r requirements.txt`)
+
+## Puesta en marcha
+
+1. **Levantar los servicios de infraestructura**:
+
+   ```bash
+   docker-compose up -d
+   ```
+
+2. **Crear el tópico de Kafka** (una sola vez):
+
+   ```bash
+   docker exec -it proyecto-final-kafka-1 kafka-topics --create \
+     --topic twitter --bootstrap-server localhost:9092
+   ```
+
+3. **Instalar dependencias de Python**:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Ejecución
+
+### Productores
+
+Cada productor genera entre 5 y 15 mensajes con un intervalo aleatorio (0.5 a 3s).
+
+```bash
+python scripts/producer.py
+```
+
+Ejecute múltiples instancias para simular varios clientes.
+
+### Consumer
+
+Escucha el tópico `twitter` y guarda los mensajes en MongoDB.
+
+```bash
+python scripts/consumer.py
+```
+
+### Pipeline de Deep Learning
+
+Procesa los mensajes no tratados en MongoDB, predice su sentimiento y almacena los resultados en MySQL.
+
+```bash
+python scripts/ml_pipeline.py
+```
+
+## Dashboard en Metabase
+
+1. Acceda a [http://localhost:3000](http://localhost:3000) y complete la configuración inicial.
+2. Configure una conexión a la base de datos MySQL (`host: mysql`, `usuario: root`, `contraseña: example`, `base: twitter`).
+3. Cree al menos **tres visualizaciones**, por ejemplo:
+   - Conteo de mensajes por sentimiento.
+   - Comentarios negativos por usuario.
+   - Evolución temporal de comentarios positivos.
+
+## Estructura de la base de datos
+
+- **MongoDB** (`twitter_db.raw_comments`): almacena mensajes crudos con campos `user_id`, `comment`, `timestamp`, `processed` y `sentiment`.
+- **MySQL** (`twitter.tweets`): contiene `user_id`, `comment`, `sentiment`, `score` y `created_at` para el análisis en el dashboard.
+
+## Notas
+
+- El modelo `distilbert-base-uncased-finetuned-sst-2-english` de Hugging Face se ejecuta directamente con PyTorch, sin utilizar `transformers.pipeline`.
+- Ajuste las variables y puertos según sea necesario para su entorno.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3.8'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.0
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+  kafka:
+    image: confluentinc/cp-kafka:7.4.0
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+  mongo:
+    image: mongo:6
+    restart: always
+    ports:
+      - "27017:27017"
+  mysql:
+    image: mysql:8
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+      MYSQL_DATABASE: twitter
+    ports:
+      - "3306:3306"
+  metabase:
+    image: metabase/metabase:latest
+    depends_on:
+      - mysql
+    ports:
+      - "3000:3000"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+kafka-python
+pymongo
+mysql-connector-python
+transformers
+torch

--- a/scripts/consumer.py
+++ b/scripts/consumer.py
@@ -1,0 +1,41 @@
+import json
+import time
+from typing import Any
+
+from kafka import KafkaConsumer
+from pymongo import MongoClient
+
+TOPIC = "twitter"
+BROKER = "localhost:9092"
+MONGO_URI = "mongodb://localhost:27017"
+DB_NAME = "twitter_db"
+COLLECTION = "raw_comments"
+
+
+def run() -> None:
+    consumer = KafkaConsumer(
+        TOPIC,
+        bootstrap_servers=BROKER,
+        value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+        auto_offset_reset="earliest",
+        enable_auto_commit=True,
+        group_id="twitter-group",
+    )
+
+    mongo = MongoClient(MONGO_URI)
+    collection = mongo[DB_NAME][COLLECTION]
+
+    for message in consumer:
+        data: Any = message.value
+        record = {
+            "user_id": data["user_id"],
+            "comment": data["comment"],
+            "timestamp": time.time(),
+            "processed": False,
+        }
+        collection.insert_one(record)
+        print(f"Stored: {record}")
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/ml_pipeline.py
+++ b/scripts/ml_pipeline.py
@@ -1,0 +1,86 @@
+import torch
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+from pymongo import MongoClient
+import mysql.connector
+
+MONGO_URI = "mongodb://localhost:27017"
+DB_NAME = "twitter_db"
+COLLECTION = "raw_comments"
+
+MYSQL_CONFIG = {
+    "host": "localhost",
+    "user": "root",
+    "password": "example",
+    "database": "twitter",
+}
+
+MODEL_NAME = "distilbert-base-uncased-finetuned-sst-2-english"
+
+
+class SentimentModel:
+    def __init__(self) -> None:
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+        self.model = (
+            AutoModelForSequenceClassification.from_pretrained(MODEL_NAME)
+            .to(self.device)
+            .eval()
+        )
+
+    def predict(self, text: str) -> tuple[str, float]:
+        inputs = self.tokenizer(text, return_tensors="pt").to(self.device)
+        with torch.no_grad():
+            logits = self.model(**inputs).logits
+            probs = torch.nn.functional.softmax(logits, dim=1)
+            score, idx = torch.max(probs, dim=1)
+            label = self.model.config.id2label[idx.item()]
+            return label, float(score.item())
+
+
+def run() -> None:
+    mongo = MongoClient(MONGO_URI)
+    collection = mongo[DB_NAME][COLLECTION]
+
+    mysql_conn = mysql.connector.connect(**MYSQL_CONFIG)
+    cursor = mysql_conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS tweets (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            user_id VARCHAR(255),
+            comment TEXT,
+            sentiment VARCHAR(32),
+            score FLOAT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    mysql_conn.commit()
+
+    model = SentimentModel()
+
+    while True:
+        doc = collection.find_one({"processed": False})
+        if not doc:
+            print("No more documents to process")
+            break
+
+        sentiment, score = model.predict(doc["comment"])
+        collection.update_one(
+            {"_id": doc["_id"]},
+            {"$set": {"processed": True, "sentiment": sentiment, "score": score}},
+        )
+
+        cursor.execute(
+            "INSERT INTO tweets (user_id, comment, sentiment, score) VALUES (%s, %s, %s, %s)",
+            (doc["user_id"], doc["comment"], sentiment, score),
+        )
+        mysql_conn.commit()
+        print(f"Processed {doc['_id']} -> {sentiment} ({score:.4f})")
+
+    cursor.close()
+    mysql_conn.close()
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/producer.py
+++ b/scripts/producer.py
@@ -1,0 +1,45 @@
+import json
+import random
+import time
+import uuid
+
+from kafka import KafkaProducer
+
+TOPIC = "twitter"
+BROKER = "localhost:9092"
+
+COMMENTS = [
+    "I love this!",
+    "This is terrible",
+    "Amazing work",
+    "I hate this!",
+    "Could be better",
+    "Absolutely fantastic",
+]
+
+
+def generate_message() -> dict:
+    return {
+        "user_id": f"user_{uuid.uuid4().hex[:8]}",
+        "comment": random.choice(COMMENTS),
+    }
+
+
+def run():
+    producer = KafkaProducer(
+        bootstrap_servers=BROKER,
+        value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+    )
+    num_messages = random.randint(5, 15)
+    for _ in range(num_messages):
+        msg = generate_message()
+        producer.send(TOPIC, msg)
+        producer.flush()
+        print(f"Sent: {msg}")
+        time.sleep(random.uniform(0.5, 3.0))
+
+    producer.close()
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- Add Docker Compose stack for Kafka, MongoDB, MySQL and Metabase
- Implement Python scripts for Kafka producers, consumer storing raw data in MongoDB, and ML pipeline predicting sentiment into MySQL
- Document setup and execution steps in README
- Use explicit PyTorch sentiment model without transformers pipeline

## Testing
- `python -m py_compile scripts/*.py && echo py_compile_success`


------
https://chatgpt.com/codex/tasks/task_e_689e6271b7948322a4c91caf0121578c