### PR TITLE
Handle unavailable Kafka broker in producer

### DIFF
--- a/scripts/producer.py
+++ b/scripts/producer.py
@@ -1,13 +1,18 @@
 import json
+import os
 import random
 import time
 import uuid
 from pathlib import Path
 
 from kafka import KafkaProducer
+from kafka.errors import NoBrokersAvailable
 
 TOPIC = "twitter"
-BROKER = "localhost:9092"
+# Allow broker configuration via environment variable for flexibility in
+# different deployment environments.  Default to the local Kafka instance
+# used during development.
+BROKER = os.getenv("KAFKA_BROKER", "localhost:9092")
 
 DATA_FILE = Path(__file__).resolve().parent.parent / "tweets_1000_labeled.jsonl"
 
@@ -39,11 +44,34 @@ def generate_message() -> dict[str, str]:
     return random.choice(MESSAGES)
 
 
+def create_producer(retries: int = 5, delay: float = 1.0) -> KafkaProducer | None:
+    """Create a Kafka producer with simple retry logic.
+
+    If the Kafka broker is not available, the function will retry a few times
+    before giving up and returning ``None``.  This prevents the script from
+    crashing with a ``NoBrokersAvailable`` error when Kafka is temporarily
+    unreachable.
+    """
+
+    for attempt in range(retries):
+        try:
+            return KafkaProducer(
+                bootstrap_servers=BROKER,
+                value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+            )
+        except NoBrokersAvailable:
+            if attempt == retries - 1:
+                break
+            time.sleep(delay)
+    return None
+
+
 def run() -> None:
-    producer = KafkaProducer(
-        bootstrap_servers=BROKER,
-        value_serializer=lambda v: json.dumps(v).encode("utf-8"),
-    )
+    producer = create_producer()
+    if producer is None:
+        print("Kafka broker is not available. Exiting.")
+        return
+
     num_messages = random.randint(5, 15)
     for _ in range(num_messages):
         msg = generate_message()


### PR DESCRIPTION
## Summary
- allow configuring Kafka broker via environment variable
- add retry logic so producer exits cleanly when Kafka is unavailable

## Testing
- `pytest`
- `python -m py_compile scripts/producer.py`


------
https://chatgpt.com/codex/tasks/task_e_689fccea6acc832284a9e43e41e9fc6d